### PR TITLE
feat: add Anniversary and Classic Era realms to realm data dropdown

### DIFF
--- a/tsm/core/services/auction.py
+++ b/tsm/core/services/auction.py
@@ -100,9 +100,11 @@ class AuctionDataService:
             if not app_data:
                 continue  # AppHelper not installed for this game version, skip
 
-            # Classic Era and Anniversary: only include realms the user has active
-            # characters on.  Mirrors the Windows app's get_active_*_factionrealms()
-            # filter so users who only play retail are not shown hundreds of extra rows.
+            # Classic Era and Anniversary: when active characters are detected,
+            # filter to only those realms.  When none are found (SavedVariables
+            # not yet written, or user added realms manually before logging in),
+            # process all realms the API returns so manually-added realms still
+            # appear in the table.
             active_factionrealms: set[tuple[str, str]] | None = None
             if gv_dir in ("_classic_era_", "_anniversary_"):
                 from tsm.wow.accounts import get_active_factionrealms
@@ -112,11 +114,10 @@ class AuctionDataService:
                     active |= await loop.run_in_executor(
                         None, get_active_factionrealms, install, gv_dir
                     )
-                if not active:
-                    # No characters on this game version - skip all rows for it
-                    logger.debug("No active %s characters found, skipping realm list", gv_dir)
-                    continue
-                active_factionrealms = active
+                if active:
+                    active_factionrealms = active
+                else:
+                    logger.info("No active %s characters found, showing all API realms", gv_dir)
 
             # Process realms, dynamic key access requires cast (key is a runtime variable)
             for realm in cast(list[RealmEntry], result.get(realms_key, [])):

--- a/tsm/ui/app_window.py
+++ b/tsm/ui/app_window.py
@@ -417,14 +417,24 @@ class AppWindow(QMainWindow):
             return
         from tsm.workers.bridge import AsyncBridge
 
+        async def _fetch_both():
+            realm_list = await self._api_client.realms.list()
+            status = await self._api_client.status.get()
+            return realm_list, status
+
         bridge = AsyncBridge(self)
         bridge.result_ready.connect(self._on_realm_list_fetched)
-        bridge.run(self._api_client.realms.list())
+        bridge.run(_fetch_both())
 
     def _on_realm_list_fetched(self, data) -> None:
-        if not isinstance(data, dict):
+        if not isinstance(data, tuple) or len(data) != 2:
             return
-        self._realm_tree_cache = build_realm_tree(data)
+        realm_list, status = data
+        if not isinstance(realm_list, dict):
+            realm_list = {}
+        if not isinstance(status, dict):
+            status = {}
+        self._realm_tree_cache = build_realm_tree(realm_list, status)
         self._realm_view.set_realm_tree(self._realm_tree_cache)
 
     def on_authenticated(self, session) -> None:

--- a/tsm/ui/views/_utils.py
+++ b/tsm/ui/views/_utils.py
@@ -45,33 +45,79 @@ def start_rate_limit_countdown(
         button.setText(label)
 
 
-def build_realm_tree(data: dict) -> dict[str, dict[str, list[dict]]]:
-    """Parse raw API realms response into a {gv_label: {region: [realm_dict]}} tree.
+_GV_LABEL_MAP: dict[str, tuple[str, str]] = {
+    "retail": ("Retail", "retail"),
+    "bcc": ("Progression", "bcc"),
+    "classic": ("Classic Era", "classic"),
+    "anniversary": ("Anniversary", "anniversary"),
+}
 
-    Only "retail" and "bcc" game versions are included (matches original TSM behaviour).
+# Status endpoint keys that provide realm lists for game versions not covered
+# by the realms2/list endpoint.  Maps status key -> (gv_label, api_gv).
+_STATUS_REALM_KEYS: dict[str, tuple[str, str]] = {
+    "extraAnniversaryRealms": ("Anniversary", "anniversary"),
+    "extraClassicRealms": ("Classic Era", "classic"),
+}
+
+
+def build_realm_tree(
+    realm_list: dict,
+    status: dict | None = None,
+) -> dict[str, dict[str, list[dict]]]:
+    """Parse API responses into a {gv_label: {region: [realm_dict]}} tree.
+
+    *realm_list* comes from ``realms2/list`` (has retail + bcc).
+    *status* comes from ``GET /v2/status`` and supplies anniversary / classic
+    realms via ``extraAnniversaryRealms`` / ``extraClassicRealms``.
     Each realm dict has keys: id, name, gameVersion.
     """
     tree: dict[str, dict[str, list[dict]]] = {}
-    for game_ver, realms in data.items():
+
+    # 1) realms2/list — retail & bcc (and anything else the API returns)
+    for game_ver, realms in realm_list.items():
         if not isinstance(realms, list):
             continue
-        if game_ver == "retail":
-            gv_label, api_gv = "Retail", "retail"
-        elif game_ver == "bcc":
-            gv_label, api_gv = "Progression", "bcc"
-        else:
+        mapping = _GV_LABEL_MAP.get(game_ver)
+        if mapping is None:
             continue
-        tree.setdefault(gv_label, {})
-        for realm in realms:
-            region = realm.get("region", "")
-            tree[gv_label].setdefault(region, []).append(
-                {
-                    "id": realm.get("id", 0),
-                    "name": realm.get("name", ""),
-                    "gameVersion": api_gv,
-                }
-            )
+        gv_label, api_gv = mapping
+        _insert_realms(tree, gv_label, api_gv, realms)
+
+    # 2) status endpoint — anniversary & classic era
+    if status:
+        for status_key, (gv_label, api_gv) in _STATUS_REALM_KEYS.items():
+            realms = status.get(status_key, [])
+            if isinstance(realms, list) and realms:
+                _insert_realms(tree, gv_label, api_gv, realms)
+
     for gv in tree.values():
         for region in gv:
             gv[region].sort(key=lambda r: r["name"])
     return tree
+
+
+def _insert_realms(
+    tree: dict[str, dict[str, list[dict]]],
+    gv_label: str,
+    api_gv: str,
+    realms: list[dict],
+) -> None:
+    gv_node = tree.setdefault(gv_label, {})
+    seen: set[tuple[str, str]] = set()
+    for existing_realms in gv_node.values():
+        for r in existing_realms:
+            seen.add((r.get("name", ""), r.get("region", "")))
+
+    for realm in realms:
+        name = realm.get("name", "")
+        region = realm.get("region", "")
+        if (name, region) in seen:
+            continue
+        seen.add((name, region))
+        gv_node.setdefault(region, []).append(
+            {
+                "id": realm.get("id", 0),
+                "name": name,
+                "gameVersion": api_gv,
+            }
+        )

--- a/tsm/ui/views/realm_data.py
+++ b/tsm/ui/views/realm_data.py
@@ -127,7 +127,7 @@ class RealmDataView(QWidget):
 
         # Left group: realm selectors + add button
         self._gv_combo = QComboBox()
-        self._gv_combo.setFixedWidth(110)
+        self._gv_combo.setFixedWidth(130)
         self._gv_combo.currentIndexChanged.connect(self._on_gv_changed)
         outer.addWidget(self._gv_combo)
 


### PR DESCRIPTION
## Summary
- **Add Realm dropdown**: The `realms2/list` API only returns `retail` and `bcc` keys. Anniversary and Classic Era realms are now also fetched from the `status` endpoint (`extraAnniversaryRealms` / `extraClassicRealms`) and merged into the dropdown tree, so users can select and add Anniversary or Classic Era realms.
- **Character filter relaxed**: Previously, if `get_active_factionrealms()` found no characters for Anniversary/Classic Era, the entire game version was skipped — no realms shown, no data synced. Now it falls through without filtering, so manually-added realms still appear in the table (e.g. before the user has logged into WoW with TSM).
- **Combo box widened**: Game version dropdown widened from 110px to 130px to fit "Anniversary" and "Classic Era" labels.

## Changes
| File | What changed |
|---|---|
| `tsm/ui/views/_utils.py` | `build_realm_tree()` now accepts a second `status` dict and merges anniversary/classic realms from it |
| `tsm/ui/app_window.py` | `_prefetch_realm_list()` fetches both `realms2/list` and `status` endpoints |
| `tsm/core/services/auction.py` | Character filter no longer skips the game version when no characters are detected |
| `tsm/ui/views/realm_data.py` | Game version combo box widened to 130px |

## Test plan
- [x] Log in and verify the Add Realm dropdown shows Anniversary and Classic Era alongside Retail and Progression
- [x] Add an Anniversary realm and verify it appears in the realm data table
- [x] Verify data syncs for the added Anniversary realm (check AppData.lua)
- [x] Verify Retail and Progression realms still work as before